### PR TITLE
Replace broken Edge middleware example with working proxy pattern

### DIFF
--- a/.changeset/remove-broken-edge-middleware-example.md
+++ b/.changeset/remove-broken-edge-middleware-example.md
@@ -1,0 +1,5 @@
+---
+'@markdown-for-agents/nextjs': patch
+---
+
+Remove broken "Next.js Middleware (Edge)" example from docs that used `fetch(request.url)` inside edge middleware, which causes an infinite loop. Next.js edge middleware cannot intercept response bodies — use `withMarkdown` with App Router route handlers instead.

--- a/.changeset/remove-broken-edge-middleware-example.md
+++ b/.changeset/remove-broken-edge-middleware-example.md
@@ -2,4 +2,4 @@
 '@markdown-for-agents/nextjs': patch
 ---
 
-Remove broken "Next.js Middleware (Edge)" example from docs that used `fetch(request.url)` inside edge middleware, which causes an infinite loop. Next.js edge middleware cannot intercept response bodies — use `withMarkdown` with App Router route handlers instead.
+Replace broken "Next.js Middleware (Edge)" example with a working "Next.js Proxy (Site-wide)" pattern that avoids infinite loops by using `accept: 'text/html'` on the inner fetch.

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -201,6 +201,40 @@ import { convert } from 'markdown-for-agents';
 const { markdown } = convert(html, { rules: [nextImageRule] });
 ```
 
+### Next.js Proxy (Site-wide)
+
+For site-wide conversion without wrapping every route handler, you can use a [Next.js proxy](https://nextjs.org/docs/app/building-your-application/routing/middleware). The proxy checks the `Accept` header and fetches the page as HTML before converting:
+
+```ts
+// proxy.ts
+import { NextRequest, NextResponse, NextFetchEvent } from 'next/server';
+import { withMarkdown } from '@markdown-for-agents/nextjs';
+
+const options = {
+    extract: true,
+    deduplicate: true,
+    contentSignal: { aiTrain: true, search: true, aiInput: true }
+};
+
+export async function proxy(request: NextRequest, event: NextFetchEvent) {
+    const accept = request.headers.get('accept') ?? '';
+    if (!accept.includes('text/markdown')) {
+        return NextResponse.next();
+    }
+
+    const handler = withMarkdown(async (req: NextRequest) => fetch(req.url, { headers: { accept: 'text/html' } }), { ...options, baseUrl: request.nextUrl.origin });
+
+    return (await handler(request, event)) ?? NextResponse.next();
+}
+
+export const config = {
+    matcher: ['/', '/about', '/blog/:slug*']
+};
+```
+
+> **Note:** This pattern makes a second HTTP request to your own server to fetch the HTML before converting it. The inner `fetch` uses `accept: 'text/html'`, so it bypasses the proxy and renders the page normally — no infinite loop. The extra round trip only happens for
+> `Accept: text/markdown` requests. For zero-overhead site-wide conversion, use a reverse proxy with [`@markdown-for-agents/web`](#web-standard-generic) instead.
+
 ## Web Standard (Generic)
 
 ```bash

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -201,24 +201,6 @@ import { convert } from 'markdown-for-agents';
 const { markdown } = convert(html, { rules: [nextImageRule] });
 ```
 
-### Next.js Middleware (Edge)
-
-You can also use it in Next.js middleware for site-wide conversion:
-
-```ts
-// middleware.ts
-import { withMarkdown } from '@markdown-for-agents/nextjs';
-
-const handler = withMarkdown(async request => {
-    const response = await fetch(request.url, {
-        headers: { accept: 'text/html' }
-    });
-    return response;
-});
-
-export default handler;
-```
-
 ## Web Standard (Generic)
 
 ```bash

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -232,8 +232,37 @@ export const config = {
 };
 ```
 
-> **Note:** This pattern makes a second HTTP request to your own server to fetch the HTML before converting it. The inner `fetch` uses `accept: 'text/html'`, so it bypasses the proxy and renders the page normally — no infinite loop. The extra round trip only happens for
-> `Accept: text/markdown` requests. For zero-overhead site-wide conversion, use a reverse proxy with [`@markdown-for-agents/web`](#web-standard-generic) instead.
+#### How it works
+
+The inner `fetch` sends `accept: 'text/html'`, so when the request re-enters the proxy it hits the early `return NextResponse.next()` and renders the page normally — no infinite loop. Only `Accept: text/markdown` requests take this path; all other traffic passes straight through.
+
+#### Tradeoffs
+
+This pattern makes a **second HTTP request** to your own server for every Markdown conversion. Next.js proxy runs _before_ page rendering and has no access to the response body, so there is no way to avoid this round trip within Next.js itself.
+
+In practice this is usually fine:
+
+- **Latency** — the second request is localhost-to-localhost (or edge-to-edge on Vercel), so it adds minimal overhead.
+- **Compute** — your page renders twice for AI agent requests. For static or ISR pages this is a cache hit. For dynamic pages the extra render is the main cost.
+- **Scope control** — use `config.matcher` to limit which routes are eligible, so non-content pages (API routes, auth, assets) are never double-fetched.
+
+To avoid the double fetch, wrap individual route handlers instead. This gives you direct access to the response body with no extra round trip:
+
+```ts
+// app/api/article/route.ts
+import { withMarkdown } from '@markdown-for-agents/nextjs';
+
+async function handler(request: Request) {
+    const html = await renderArticle();
+    return new Response(html, {
+        headers: { 'content-type': 'text/html' }
+    });
+}
+
+export const GET = withMarkdown(handler, { extract: true });
+```
+
+The route handler pattern is per-route, so you need to wrap each endpoint individually. Choose the proxy pattern for broad coverage with minimal setup, or route handler wrapping when you want zero-overhead conversion on specific endpoints.
 
 ## Web Standard (Generic)
 


### PR DESCRIPTION
## Summary

Replaced the broken "Next.js Middleware (Edge)" documentation example with a working "Next.js Proxy (Site-wide)" pattern that properly handles site-wide HTML-to-Markdown conversion without infinite loops.

## Key Changes

- **Renamed section** from "Next.js Middleware (Edge)" to "Next.js Proxy (Site-wide)" to better reflect the actual pattern
- **Rewrote the example** to use a proper proxy implementation that:
  - Checks the `Accept` header for `text/markdown` requests
  - Uses `accept: 'text/html'` on the inner fetch to prevent infinite loops
  - Returns early for non-Markdown requests to pass through normally
- **Added "How it works" section** explaining the infinite loop prevention mechanism
- **Added "Tradeoffs" section** documenting:
  - The double HTTP request cost and why it's acceptable
  - Latency, compute, and scope control considerations
  - Alternative route handler wrapping pattern for zero-overhead conversion on specific endpoints
- **Included route handler example** showing the per-endpoint alternative approach

## Implementation Details

The key insight is that the inner `fetch` explicitly sends `accept: 'text/html'`, so when the request re-enters the proxy, it hits the early `return NextResponse.next()` guard and renders normally. Only requests with `Accept: text/markdown` headers take the conversion path, preventing infinite loops while maintaining site-wide coverage.

The documentation now clearly presents both patterns (proxy for broad coverage vs. route handlers for zero overhead) so users can choose based on their needs.